### PR TITLE
Bætti Íslandsbanka við sem samstarfsaðila Kass

### DIFF
--- a/src/templates/tilnefningar.pug
+++ b/src/templates/tilnefningar.pug
@@ -112,7 +112,7 @@ block content
       column.large-up-offset-1.large-5
         +nominee('Íslandsbanka Appið', 'https://www.islandsbanki.is/einstaklingar/netlausnir/app/', ['Íslandsbanki', 'Kolibri'])
       column.large-5
-        +nominee('Kass', 'https://kass.is', ['Memento Payments'])
+        +nominee('Kass', 'https://kass.is', ['Íslandsbanki','Memento Payments'])
       column.large-up-offset-1.large-5
         +nominee('Strætó app', 'https://www.straeto.is/is/verslun/straeto-appi', ['Stokkur Software ehf.'])
       column.large-5


### PR DESCRIPTION
Það vantaði að nefna Íslandsbanka við tilnefninguna fyrir Kass - Unnur benti á að gera það í gegnum pull request